### PR TITLE
Pretty print Date instances in stack trace

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -2,13 +2,9 @@
 
 const util = require("util");
 
-const constants = require("./constants");
+const JsonReplacer = require("./util/json-replacer");
 
-class Private {
-  static replacer(key, value) {
-    return (util.isUndefined(value)) ? "undefined" : value;
-  }
-}
+const constants = require("./constants");
 
 /**
  * Error Builder allows you to use optional functions to build an error object.  The error can have appended stack traces and debug params to assist with debugging.
@@ -139,7 +135,7 @@ class Error {
 
   _build_(error) {
     error.stack = (!this._debugParams_) ? error.stack :
-      util.format(constants.templates.StackDebugParamsTemplate, error.stack, constants.DebugPrefix, JSON.stringify(this._debugParams_, Private.replacer, 2));
+      util.format(constants.templates.StackDebugParamsTemplate, error.stack, constants.DebugPrefix, JSON.stringify(this._debugParams_, JsonReplacer.replace, 2));
 
     for (let currentAppendTo of this._appendTo_) {
       error.stack = util.format(constants.templates.AppendToTemplate, error.stack, constants.StackTraceDelimiter, currentAppendTo.stack);

--- a/lib/util/json-replacer.js
+++ b/lib/util/json-replacer.js
@@ -1,0 +1,14 @@
+const util = require("util");
+
+class JsonReplacer {
+  static replace(key) {
+    let replacedValue = this[key];
+
+    replacedValue = util.isDate(replacedValue) ? `Date { ${replacedValue.toISOString()} }` : replacedValue;
+    replacedValue = util.isUndefined(replacedValue) ? "undefined" : replacedValue;
+
+    return replacedValue;
+  }
+}
+
+module.exports = JsonReplacer;


### PR DESCRIPTION
Code to better indicate that a `Date` in a stack trace is actually a `Date`, and not just a date string.